### PR TITLE
Freebsd support

### DIFF
--- a/mk/install.sh
+++ b/mk/install.sh
@@ -235,10 +235,10 @@ select_pkgs_freebsd()
     ERROR=$?
     if [ $ERROR != 0 ]
     then
-    	XGU="xe-guest-utilities"
+        XGU="xe-guest-utilities"
     else
-    	set $PKGNAME
-	PKGNAME="$1"
+        set $PKGNAME
+        PKGNAME="$1"
         echo "${PKGNAME} already installed"
     fi
 }

--- a/mk/install.sh
+++ b/mk/install.sh
@@ -74,7 +74,7 @@ fi
 
 ARCH=$(uname -m | sed -e 's/i.86/i386/g')
 case "${ARCH}" in
-    i386|x86_64) ;;
+    i386|x86_64|amd64) ;;
     *)
 	echo "Architecture ${ARCH} is not supported"
 	exit 1
@@ -226,6 +226,21 @@ select_pkgs_xe()
     GUEST_PKG_TYPE=rpm
 
     select_rpm_utilities
+}
+
+select_pkgs_freebsd()
+{
+    GUEST_PKG_TYPE=pkg
+    PKGNAME=$(pkg info xe-guest-utilities 2>&1)
+    ERROR=$?
+    if [ $ERROR != 0 ]
+    then
+    	XGU="xe-guest-utilities"
+    else
+    	set $PKGNAME
+	PKGNAME="$1"
+        echo "${PKGNAME} already installed"
+    fi
 }
 
 update_lvm_configuration_required()
@@ -510,6 +525,14 @@ install_coreos()
     systemctl start xe-linux-distribution.service
 }
 
+install_freebsd()
+{
+    echo "Installing xe-guest-utilities from FreeBSD pkg..."
+    pkg install xe-guest-utilities
+    echo "Installation complete. Starting xenguest"
+    service xenguest start
+}
+
 case "${os_distro}" in
     rhel|centos|oracle|fedora)         select_pkgs_rhel ;;
     scientific|neokylin|asianux|turbo) select_pkgs_rhel ;;
@@ -519,6 +542,7 @@ case "${os_distro}" in
     xe-ddk|xe-sdk)                     select_pkgs_xe ;;
     CoreOS)                            select_pkgs_coreos ;;
     "Container Linux by CoreOS")       select_pkgs_coreos ;;
+    FreeBSD)                           select_pkgs_freebsd ;;
     *)                  failure "Unknown Linux distribution \`${os_distro}'." ;;
 esac
 
@@ -545,7 +569,7 @@ if [ -n "${ECRYPTFS_UTILS}" ] ; then
 	fi
     done
 fi
-if [ -n "${XGU}" ] ; then
+if [ -n "${XGU}" ] && [ "${os_distro}" != FreeBSD ] ; then
     for P in ${XGU} ; do
 	if [ ! -f "${P}" ] ; then
 	    echo "Warning: xe-guest-utilities ${P} not found."
@@ -671,6 +695,7 @@ case ${GUEST_PKG_TYPE} in
     rpm) install_rpms ;;
     deb) install_debs ;;
     coreos) install_coreos ;;
+    pkg) install_freebsd ;;
 esac
 
 if [ -n "${KERNEL}" -o -n "${XGU}" ] ; then

--- a/mk/install.sh
+++ b/mk/install.sh
@@ -569,7 +569,7 @@ if [ -n "${ECRYPTFS_UTILS}" ] ; then
 	fi
     done
 fi
-if [ -n "${XGU}" ] && [ "${os_distro}" != FreeBSD ] ; then
+if [ -n "${XGU}" ] && [ "${os_distro}" != "FreeBSD" ] ; then
     for P in ${XGU} ; do
 	if [ ! -f "${P}" ] ; then
 	    echo "Warning: xe-guest-utilities ${P} not found."
@@ -577,7 +577,7 @@ if [ -n "${XGU}" ] && [ "${os_distro}" != FreeBSD ] ; then
 	fi
     done
 fi
-if [ -z "${XGU}" ] ; then
+if [ -z "${XGU}" ] && [ "${os_distro}" != "FreeBSD" ] ; then
     echo ""
     echo "Certain guest features will not be active until a version of "
     echo "xe-guest-utilities is installed."

--- a/mk/xe-linux-distribution
+++ b/mk/xe-linux-distribution
@@ -478,7 +478,7 @@ identify_yinhe()
     fi
     
     yinhe_osname="Yinhe Kylin Linux ${major}.${minor}"
-    
+    write_to_output "${distro}" "${major}" "${minor}" "${yinhe_osname}"
 }
 
 identify_boot2docker()
@@ -495,7 +495,6 @@ identify_boot2docker()
     minor=$(awk -F. '{printf("%s.%s", $2, $3)}' /etc/version)
 
     write_to_output "boot2docker" "${major}" "${minor}" "boot2docker $(head -n 1 /etc/version)"
-    write_to_output "${distro}" "${major}" "${minor}" "${yinhe_osname}"
 }
 
 identify_freebsd()

--- a/mk/xe-linux-distribution
+++ b/mk/xe-linux-distribution
@@ -478,7 +478,6 @@ identify_yinhe()
     fi
     
     yinhe_osname="Yinhe Kylin Linux ${major}.${minor}"
-    write_to_output "${distro}" "${major}" "${minor}" "${yinhe_osname}"
 }
 
 identify_boot2docker()
@@ -496,6 +495,27 @@ identify_boot2docker()
 
     write_to_output "boot2docker" "${major}" "${minor}" "boot2docker $(head -n 1 /etc/version)"
 
+}
+
+identify_freebsd()
+{
+
+    if [ ! -x /usr/bin/uname ] || [ $(/usr/bin/uname -s) != "FreeBSD" ]
+    then
+    	return 1
+    fi
+
+    distro="FreeBSD"
+    release=$(uname -r)
+    IFS="-"
+    set - $release
+    version=$1
+    IFS="."
+    set - $version
+    major=$1
+    minor=$2
+    osname="FreeBSD $release"
+    write_to_output "${distro}" "${major}" "${minor}" "${osname}"
 }
 
 if [ $# -eq 1 ] ; then
@@ -521,6 +541,7 @@ if [ -z "${TEST}" ] ; then
     identify_debian /etc/debian_version && exit 0
     identify_boot2docker /etc/boot2docker && exit 0
     identify_sangoma /etc/centos-release && exit 0
+    identify_freebsd && exit 0
 
 
     if [ $# -eq 1 ] ; then

--- a/mk/xe-linux-distribution
+++ b/mk/xe-linux-distribution
@@ -478,6 +478,7 @@ identify_yinhe()
     fi
     
     yinhe_osname="Yinhe Kylin Linux ${major}.${minor}"
+    
 }
 
 identify_boot2docker()
@@ -494,7 +495,7 @@ identify_boot2docker()
     minor=$(awk -F. '{printf("%s.%s", $2, $3)}' /etc/version)
 
     write_to_output "boot2docker" "${major}" "${minor}" "boot2docker $(head -n 1 /etc/version)"
-
+    write_to_output "${distro}" "${major}" "${minor}" "${yinhe_osname}"
 }
 
 identify_freebsd()
@@ -502,7 +503,7 @@ identify_freebsd()
 
     if [ ! -x /usr/bin/uname ] || [ $(/usr/bin/uname -s) != "FreeBSD" ]
     then
-    	return 1
+        return 1
     fi
 
     distro="FreeBSD"


### PR DESCRIPTION
This gives `install.sh` support for detecting and doing reasonable things on [FreeBSD](https://freebsd.org/). If FreeBSD is detected, it will check to see if the `xe-guest-utilities` package is installed. If it isn't, then it will attempt to install it. (It doesn't check to see if the version installed is the latest)

### On a VM that does not have Guest Utilities

```
Detected `FreeBSD 12.0-RELEASE-p12' (FreeBSD version 12).

The following changes will be made to this Virtual Machine:
  * packages to be installed/upgraded:
    - xe-guest-utilities

Continue? [y/n]
```

If the user chooses "Y" then it will run the `pkg` command to install `xe-guest-utilities`. There is no need to get very specific about the version, because the FreeBSD `pkg` command knows what version of the OS is installed and, therefore, what repo to pull a binary package from.

### On a VM that already has Guest Utilities installed
```
Detected `FreeBSD 12.1-RELEASE-p5' (FreeBSD version 12).

xe-guest-utilities-6.2.0_2 already installed
No updates required to this Virtual Machine.
```

All the linux-specific checks for things like grub and the kernel are all harmless/skipped on FreeBSD because they test for files that don't exist on a normal FreeBSD system and skip their activities if the files aren't found. A couple checks don't do that, so I added explicit conditions to skip them if the OS is FreeBSD.