### PR TITLE
The existing regexp fails because it's not an extended regexp

### DIFF
--- a/mk/xe-linux-distribution
+++ b/mk/xe-linux-distribution
@@ -378,7 +378,7 @@ identify_sangoma()
     fi
 
     eval $(sed -rn \
-              's/^Sangoma Linux release \([0-9]*\)\.\([0-9]*\)\(\.[0-9]*\)\? (.*)/distro=sangoma;major=\1;minor=\2/gp;' \
+              's/^Sangoma Linux release ([0-9]*)\.([0-9]*).*$/distro=sangoma;major=\1;minor=\2/gp;' \
               "${sangoma_release}")
 
     if [ -z "${major}" -o -z "${distro}" ] ; then


### PR DESCRIPTION
The existing regexp fails because it's not an extended regexp
and since sed is called with -r it must be an extended regexp.
So I fixed that and also synced with the latest regexp for CentOS.