### PR TITLE
Fix FreePBX detection when centos-release is missing

### DIFF
--- a/mk/xe-linux-distribution
+++ b/mk/xe-linux-distribution
@@ -586,6 +586,7 @@ if [ -z "${TEST}" ] ; then
     identify_lsb lsb_release         && exit 0
     identify_debian /etc/debian_version && exit 0
     identify_boot2docker /etc/boot2docker && exit 0
+    identify_sangoma /etc/sangoma-release && exit 0
     identify_sangoma /etc/centos-release && exit 0
     identify_freebsd && exit 0
 


### PR DESCRIPTION
For some reason, some FreePBX systems have a centos-release file and
others don't. So we read sangoma-release first, which should always be
present (and if it isn't we still check centos-release just in case)

Signed-off-by: Samuel Verschelde <stormi-xcp@ylix.fr>