### PR TITLE
Fallback to generic /etc/os-release on unhandled distro

### DIFF
--- a/mk/xe-linux-distribution
+++ b/mk/xe-linux-distribution
@@ -240,11 +240,17 @@ identify_sles()
 
     eval $(sed -n \
 	       -e 's/^VERSION_ID="\([0-9]*\)\.\?\([0-9]*\)\?"$/major=\1;minor=\2;/gp' \
+           -e 's/^PRETTY_NAME="openSUSE MicroOS"/_pretty_name=\0;/gp'
 	       -e 's/^PRETTY_NAME="SUSE L\(inux\|INUX\) Enterprise \([a-zA-Z0-9_]*\) \([0-9]*\)\( SP[0-9]*\)\?"/_major=\3;_pretty_name=\0;/gp' \
                -e 's/^SUSE L\(inux\|INUX\) Enterprise \([a-zA-Z0-9_]*\) \([0-9]*\) (.*)/_major=\3;_pretty_name="\0";/gp;' \
                -e 's/^VERSION = \([0-9]*\)$/major=\1;/gp;' \
                -e 's/^PATCHLEVEL = \([0-9]*\)$/minor=\1;/gp;' \
 	       "${suse_release}")
+
+    if [ "${_pretty_name##*=}" = "openSUSE MicroOS" ] ; then
+        write_to_output "sles" "${major}" "${minor}" "${_pretty_name##*=}"
+        return 0
+    fi
 
     if [ -z "${major}" -o -z "${_major}" ] ; then
         return 1

--- a/mk/xe-linux-distribution
+++ b/mk/xe-linux-distribution
@@ -313,6 +313,37 @@ identify_lsb()
     write_to_output "${distro}" "${major}" "${minor}" "${description}"
 }
 
+identify_os_release()
+{
+    os_release="$1"
+    local major
+    local minor
+
+    # Use /etc/os-release to detect.
+    # NAME="SLES"
+    # VERSION="15"
+    # VERSION_ID="15"
+    # PRETTY_NAME="SUSE Linux Enterprise Server 15"
+    # ID="sles"
+    # ID_LIKE="suse"
+    # ANSI_COLOR="0;32"
+    # CPE_NAME="cpe:/o:suse:sles:15"
+
+    if [ ! -f "${os_release}" ] ; then
+        return 1
+    fi
+
+    source "${os_release}"
+
+    eval $(echo "$VERSION_ID" | \
+	    sed -n -e 's/^\([0-9]*\)\.\?\([0-9]*\).*$/major=\1;minor=\2;/gp')
+
+    major="${major:-unknown}"
+    minor="${minor:-unknown}"
+
+    write_to_output "${ID}" "${major}" "${minor}" "${PRETTY_NAME}"
+}
+
 identify_kylin()
 {
     kylin_release="$1"
@@ -592,9 +623,13 @@ if [ -z "${TEST}" ] ; then
     identify_lsb lsb_release         && exit 0
     identify_debian /etc/debian_version && exit 0
     identify_boot2docker /etc/boot2docker && exit 0
+<<<<<<< HEAD
     identify_sangoma /etc/sangoma-release && exit 0
     identify_sangoma /etc/centos-release && exit 0
     identify_freebsd && exit 0
+=======
+    identify_os_release /etc/os-release && exit 0
+>>>>>>> 9b1af3c (Support generic distributions using os-release)
 
 
     if [ $# -eq 1 ] ; then


### PR DESCRIPTION
detect PRETTY_NAME="openSUSE MicroOS" in sles os-release logic, bypass all other checks, write to output.
Signed-off-by: Andrew Robbins <andrew@robbinsa.me>