### PR TITLE
Support generic distributions using os-release

### DIFF
--- a/mk/xe-linux-distribution
+++ b/mk/xe-linux-distribution
@@ -307,6 +307,37 @@ identify_lsb()
     write_to_output "${distro}" "${major}" "${minor}" "${description}"
 }
 
+identify_os_release()
+{
+    os_release="$1"
+    local major
+    local minor
+
+    # Use /etc/os-release to detect.
+    # NAME="SLES"
+    # VERSION="15"
+    # VERSION_ID="15"
+    # PRETTY_NAME="SUSE Linux Enterprise Server 15"
+    # ID="sles"
+    # ID_LIKE="suse"
+    # ANSI_COLOR="0;32"
+    # CPE_NAME="cpe:/o:suse:sles:15"
+
+    if [ ! -f "${os_release}" ] ; then
+        return 1
+    fi
+
+    source "${os_release}"
+
+    eval $(echo "$VERSION_ID" | \
+	    sed -n -e 's/^\([0-9]*\)\.\?\([0-9]*\).*$/major=\1;minor=\2;/gp')
+
+    major="${major:-unknown}"
+    minor="${minor:-unknown}"
+
+    write_to_output "${ID}" "${major}" "${minor}" "${PRETTY_NAME}"
+}
+
 identify_kylin()
 {
     kylin_release="$1"
@@ -589,6 +620,7 @@ if [ -z "${TEST}" ] ; then
     identify_sangoma /etc/sangoma-release && exit 0
     identify_sangoma /etc/centos-release && exit 0
     identify_freebsd && exit 0
+    identify_os_release /etc/os-release && exit 0
 
 
     if [ $# -eq 1 ] ; then


### PR DESCRIPTION
The /etc/os-release file is a standardized format containing operating
system identification data. Like lsb_release it allows to get
distribution information but uses a simple file format which is meant to
be sourced in a script.

See also:
https://www.freedesktop.org/software/systemd/man/os-release.html

Signed-off-by: Stefan Agner <stefan@agner.ch>

[Additional comment by Samuel Verschelde: this commit was cherry-picked
from commit f89f95de90d9c54a13b286120d15b12711ca8393 on the upstream git
repository]