### PR TITLE
Remove "You should now reboot this Virtual Machine." message

### DIFF
--- a/mk/install.sh
+++ b/mk/install.sh
@@ -712,8 +712,4 @@ case ${GUEST_PKG_TYPE} in
     pkg) install_freebsd ;;
 esac
 
-if [ -n "${KERNEL}" -o -n "${XGU}" ] ; then
-    echo "You should now reboot this Virtual Machine."
-fi
-
 exit 0


### PR DESCRIPTION
XCP-ng guest tools documentation mentions that reboot is not needed and will be eventually be removed.

https://xcp-ng.org/docs/guests.html#supported-linux-distributions

This commit removes that message.